### PR TITLE
Fix interpreting long int form url as int instead of float.

### DIFF
--- a/src/Ginger/Request/Parameters.php
+++ b/src/Ginger/Request/Parameters.php
@@ -155,8 +155,9 @@ class Parameters
         } elseif ($input === "true") {
             $input = true;
         } elseif (is_numeric($input)) {
-            $input = (float)$input;
             if (strpos($input, ".") !== false) {
+                $input = (float)$input;
+            } else {
                 $input = (int)$input;
             }
         } elseif ($input === "on") {

--- a/src/Ginger/Request/Parameters.php
+++ b/src/Ginger/Request/Parameters.php
@@ -156,7 +156,7 @@ class Parameters
             $input = true;
         } elseif (is_numeric($input)) {
             $input = (float)$input;
-            if (!strpos($input, ".")) {
+            if (strpos($input, ".") !== false) {
                 $input = (int)$input;
             }
         } elseif ($input === "on") {


### PR DESCRIPTION
When I passed an integer like "72157679270821591" it was interpreted as float(7.2157679270821591).

This caused an error when filtering on documents from DB.

With this change "72157679270821591" is interpreted as int(72157679270821591) so I can filter on documents from DB.